### PR TITLE
Remove hdf5-static.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 9fd8008af9ba70a203a507dd094244fa70da43ddc927da93e4a852d253969ef1
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -37,7 +37,6 @@ requirements:
     - xorg-libxt
     - pgplot
     - hdf5
-    - hdf5-static  # [osx]
     - xorg-libx11
     - xorg-xproto
     - fftw
@@ -55,7 +54,6 @@ requirements:
     - xorg-libxt
     - pgplot
     - hdf5
-    - hdf5-static  # [osx]
     - fftw
     - lapack
     - lapack95


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/721 was closed in favor of https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1690 which updates the hdf5 pin. Let's try to remove `hdf5-static` and see if it works.

Closes #4 
