### PR TITLE
CLN: rely on run_exports

### DIFF
--- a/.ci_support/linux_64_build_typedebugmpinompi.yaml
+++ b/.ci_support/linux_64_build_typedebugmpinompi.yaml
@@ -30,7 +30,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/linux_64_build_typedebugmpiopenmpi.yaml
+++ b/.ci_support/linux_64_build_typedebugmpiopenmpi.yaml
@@ -30,7 +30,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/linux_64_build_typeproductionmpinompi.yaml
+++ b/.ci_support/linux_64_build_typeproductionmpinompi.yaml
@@ -30,7 +30,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/linux_64_build_typeproductionmpiopenmpi.yaml
+++ b/.ci_support/linux_64_build_typeproductionmpiopenmpi.yaml
@@ -30,7 +30,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_64_build_typedebugmpinompi.yaml
+++ b/.ci_support/osx_64_build_typedebugmpinompi.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 build_type:
 - debug
 c_compiler:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.9'
+- '10.13'
 cairo:
 - '1'
 channel_sources:
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_64_build_typedebugmpiopenmpi.yaml
+++ b/.ci_support/osx_64_build_typedebugmpiopenmpi.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 build_type:
 - debug
 c_compiler:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.9'
+- '10.13'
 cairo:
 - '1'
 channel_sources:
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_64_build_typeproductionmpinompi.yaml
+++ b/.ci_support/osx_64_build_typeproductionmpinompi.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 build_type:
 - production
 c_compiler:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.9'
+- '10.13'
 cairo:
 - '1'
 channel_sources:
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_64_build_typeproductionmpiopenmpi.yaml
+++ b/.ci_support/osx_64_build_typeproductionmpiopenmpi.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 build_type:
 - production
 c_compiler:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.9'
+- '10.13'
 cairo:
 - '1'
 channel_sources:
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_arm64_build_typedebugmpinompi.yaml
+++ b/.ci_support/osx_arm64_build_typedebugmpinompi.yaml
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_arm64_build_typedebugmpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_build_typedebugmpiopenmpi.yaml
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_arm64_build_typeproductionmpinompi.yaml
+++ b/.ci_support/osx_arm64_build_typeproductionmpinompi.yaml
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/.ci_support/osx_arm64_build_typeproductionmpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_build_typeproductionmpiopenmpi.yaml
@@ -28,7 +28,7 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
-libblas:
+libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "bmad" %}
 {% set version = "20240504-5" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
 
@@ -64,7 +64,7 @@ requirements:
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
     - openmpi  # [mpi == "openmpi" and (build_platform != target_platform)]
-    - python *
+    - python
   host:
     - readline
     - ncurses
@@ -76,7 +76,8 @@ requirements:
     - xorg-libx11
     - xorg-xproto
     - fftw
-    - libblas
+    - libopenblas
+    - libcblas
     - liblapack
     - lapack95
     - gsl ==2.6
@@ -84,24 +85,10 @@ requirements:
     - xraylib
     - {{ mpi }}  # [mpi != 'nompi']
   run:
-    - readline
-    - ncurses
-    - cairo
-    - pango
-    - xorg-libxt
     - pgplot
-    - hdf5
-    - fftw
-    - libblas
-    - liblapack
     - lapack95
-    - gsl ==2.6
     - fgsl
-    - xraylib
-    - xorg-libx11
     - xorg-xproto
-    - libopenblas
-    - libcblas
     - {{ mpi }}  # [mpi != 'nompi']
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

`run_exports` is the method that library recipes/feedstocks use to indicate ABI compatibility.
Documentation reference: https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#export-runtime-requirements

For example, listing `readline` in the run requirements is:
1. Unnecessary because its [recipe](https://github.com/conda-forge/readline-feedstock/blob/2d0cd3a6c22f07fad9bbb0116cdde9c72470b856/recipe/meta.yaml#L14-L16) has a "run_export" saying "if you needed this as a host library, you will need `{{ pin_subpackage('readline') }}` as a run library"
2. Potentially incorrect as it doesn't have the pinning information that the upstream library recipe provides. The recipe there indicates that the shared library name changes at major revisions and should have ABI compatibility with the major version. (To be honest, I'm not sure if listing both has any effect; perhaps the pinning takes precedence anyway?)

I also adjusted the libblas host dependencies to the suggested ones from the manual.

Let's see if this works...