### PR TITLE
FIX: dependents should use the exact bmad version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "bmad" %}
 {% set version = "20260108-0" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
 
@@ -41,14 +41,11 @@ build:
   {% set mpi_prefix = "nompi" %}
   {% endif %}
 
-  # string: {{ mpi_prefix }}{{ debug }}_h{{ PKG_HASH }}_{{ build }}
   string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
-
-  {% if mpi != 'nompi' %}
   run_exports:
-    - {{ name }} * {{ mpi_prefix }}_*
-    # - {{ name }} * {{ mpi_prefix }}{{ debug }}_*
-  {% endif %}
+    # Bmad does not follow semver, and aside from the Tao C interface, most of its ABI is not stable.
+    # Compiled dependencies of bmad should use the exact version.
+    - {{ pin_subpackage('bmad', exact=True) }}
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

**Note**

This is in preparation for the upcoming cppbmad/pybmad conda-forge recipes.
I think pytao can be updated with an `ignore_run_exports` of bmad, as the Tao C API should be considered stable.