### PR TITLE
REF: undo pin subpackage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "bmad" %}
 {% set version = "20260109-1" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Notes

This apparently broke hash metadata for subpackages. I don't know if I'm doing something dumb here or if it's a conda bug (or what?). It resulted in hashes like this:

```
 bmad =20260108.0 nompi_h1234567_101 does not exist (perhaps a typo or a missing channel).
```

Note the garbage hash `h1234567`, which is reflected in the package metadata:
```
bmad-20260109.1 $ rg 123456
info/run_exports.json
1:{"weak": ["bmad 20260109.1 nompi_h1234567_100"]}

info/recipe/meta.yaml
16:    - bmad 20260109.1 nompi_h1234567_100
```

This still installs, but downstream packages which try to pin bmad exactly struggle. Hours wasted this morning! 🤦 